### PR TITLE
fix: jumpy scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -105,17 +105,22 @@ function preventDefault(e) {
 				// then this is likely to be the moment the person just began scrolling,
 				// and we're likely to see a jumpy behaviour due to an abnormal 'delta' value,
 				// so , we ignore this delta value, and do nothing.
-				console.log(`\n\n\n\nwon't execute scrollBy for this next value of delta\n(because it is likely to cause jumpy behaviour)`)
-			} else {
+				console.log(`\n\n\n\n---------------------------------------------------\n\n\n\nwon't execute scrollBy for this next value of delta\n(because it is likely to cause jumpy behaviour)`)
+			} 
+			else {
 				if(delta > 0 /* person is trying to scroll up */) scrollFactor = scrollFactorAtTop
+				console.log(`scrollTo wants to go to: ${currentlyAt + (-delta * scrollFactor)}`)
 				window.scrollTo({
 					/* info: https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo */
 					top: currentlyAt + (-delta * scrollFactor),
 					behavior: "instant",
 				})
+				console.log(`currently at: ${document.documentElement.scrollTop}`)
 			}
 			const d = new Date()
 			console.log(`time ${d.getMinutes()}:${d.getSeconds()}:${d.getMilliseconds()} | delta = ${delta}`)
+			console.log(`pageYOffst: ${e.view.pageYOffset}`)
+			console.log(`newy: ${Math.round(newy)} | oldy: ${Math.round(oldy)}`)
 			oldy = newy
 			oldtime = newtime
 			break;

--- a/script.js
+++ b/script.js
@@ -108,7 +108,11 @@ function preventDefault(e) {
 				console.log(`\n\n\n\nwon't execute scrollBy for this next value of delta\n(because it is likely to cause jumpy behaviour)`)
 			} else {
 				if(delta > 0 /* person is trying to scroll up */) scrollFactor = scrollFactorAtTop
-				window.scrollBy({ top: -delta * scrollFactor/*, behavior: 'smooth'*/ })
+				window.scrollTo({
+					/* info: https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo */
+					top: currentlyAt + (-delta * scrollFactor),
+					behavior: "instant",
+				})
 			}
 			const d = new Date()
 			console.log(`time ${d.getMinutes()}:${d.getSeconds()}:${d.getMilliseconds()} | delta = ${delta}`)

--- a/script.js
+++ b/script.js
@@ -105,22 +105,17 @@ function preventDefault(e) {
 				// then this is likely to be the moment the person just began scrolling,
 				// and we're likely to see a jumpy behaviour due to an abnormal 'delta' value,
 				// so , we ignore this delta value, and do nothing.
-				console.log(`\n\n\n\n---------------------------------------------------\n\n\n\nwon't execute scrollBy for this next value of delta\n(because it is likely to cause jumpy behaviour)`)
-			} 
-			else {
+				console.log(`\n\n\n\nwon't execute scrollBy for this next value of delta\n(because it is likely to cause jumpy behaviour)`)
+			} else {
 				if(delta > 0 /* person is trying to scroll up */) scrollFactor = scrollFactorAtTop
-				console.log(`scrollTo wants to go to: ${currentlyAt + (-delta * scrollFactor)}`)
 				window.scrollTo({
 					/* info: https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo */
 					top: currentlyAt + (-delta * scrollFactor),
 					behavior: "instant",
 				})
-				console.log(`currently at: ${document.documentElement.scrollTop}`)
 			}
 			const d = new Date()
 			console.log(`time ${d.getMinutes()}:${d.getSeconds()}:${d.getMilliseconds()} | delta = ${delta}`)
-			console.log(`pageYOffst: ${e.view.pageYOffset}`)
-			console.log(`newy: ${Math.round(newy)} | oldy: ${Math.round(oldy)}`)
 			oldy = newy
 			oldtime = newtime
 			break;


### PR DESCRIPTION
attempted fix. 
(not verified due to lack of access to test-device.)

what was the bug?:
- scrolling is jumpy especially near the top of the document. 
- noticed this on ios safari browsers on newer iphones. (not noticed on my iphone se gen2 and iphone 11 pro.)
